### PR TITLE
Use 'inference' instead of 'prediction'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ const topics = await alloraClient.getAllTopics();
 // Fetch topic inference by ID
 const ethPrice5m = await  alloraClient.getInferenceByTopicID(3);
 
-// Fetch asset price prediction
-const btc8h = await alloraClient.getPricePrediction(
-  PricePredictionToken.BTC,
-  PricePredictionTimeframe.EIGHT_HOURS
+// Fetch asset price inference
+const btc8h = await alloraClient.getPriceInference(
+  PriceInferenceToken.BTC,
+  PriceInferenceTimeframe.EIGHT_HOURS
 );
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alloralabs/allora-sdk",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "publishConfig": {
@@ -8,8 +8,8 @@
   },
   "homepage": "https://github.com/allora-network/allora-sdk-ts",
   "repository": {
-      "type": "git",
-      "url": "git+https://github.com/allora-network/allora-sdk-ts.git"
+    "type": "git",
+    "url": "git+https://github.com/allora-network/allora-sdk-ts.git"
   },
   "scripts": {
     "format": "npx prettier -w ./*",

--- a/src/v2/api-client.ts
+++ b/src/v2/api-client.ts
@@ -8,12 +8,12 @@ export enum ChainID {
   MAINNET = "allora-mainnet-1",
 }
 
-export enum PricePredictionToken {
+export enum PriceInferenceToken {
   BTC = "BTC",
   ETH = "ETH",
 }
 
-export enum PricePredictionTimeframe {
+export enum PriceInferenceTimeframe {
   FIVE_MIN = "5m",
   EIGHT_HOURS = "8h",
 }
@@ -129,22 +129,22 @@ export class AlloraAPIClient {
     );
 
     if (!response.data?.inference_data) {
-      throw new Error("Failed to fetch price prediction");
+      throw new Error("Failed to fetch price inference");
     }
     return response.data;
   }
 
   /**
-   * Fetches a price prediction for a specific asset and timeframe from the Allora API.
+   * Fetches a price inference for a specific asset and timeframe from the Allora API.
    *
-   * @param {PricePredictionToken} asset - The asset to get price prediction for
-   * @param {PricePredictionTimeframe} timeframe - The timeframe to get price prediction for
+   * @param {PriceInferenceToken} asset - The asset to get price inference for
+   * @param {PriceInferenceTimeframe} timeframe - The timeframe to get price inference for
    * @returns {Promise<AlloraInference>} A promise that resolves to the inference data
    * @throws {Error} If the API request fails or returns an unsuccessful status
    */
-  async getPricePrediction(
-    asset: PricePredictionToken,
-    timeframe: PricePredictionTimeframe,
+  async getPriceInference(
+    asset: PriceInferenceToken,
+    timeframe: PriceInferenceTimeframe,
     signatureFormat: SignatureFormat = SignatureFormat.ETHEREUM_SEPOLIA,
   ): Promise<AlloraInference> {
     const response = await this.fetchAPIResponse<AlloraInference>(
@@ -152,7 +152,7 @@ export class AlloraAPIClient {
     );
 
     if (!response.data?.inference_data) {
-      throw new Error("Failed to fetch price prediction");
+      throw new Error("Failed to fetch price inference");
     }
     return response.data;
   }

--- a/test/api-client.integration.test.ts
+++ b/test/api-client.integration.test.ts
@@ -1,8 +1,8 @@
 import {
   AlloraAPIClient,
   ChainSlug,
-  PricePredictionToken,
-  PricePredictionTimeframe,
+  PriceInferenceToken,
+  PriceInferenceTimeframe,
 } from "../src/v2";
 
 const DEFAULT_TEST_TIMEOUT = 30000;
@@ -56,19 +56,19 @@ describe("AlloraAPIClient Integration Tests", () => {
     );
   });
 
-  describe("getPricePrediction", () => {
+  describe("getPriceInference", () => {
     it(
-      "should fetch BTC price prediction",
+      "should fetch BTC price inference",
       async () => {
-        const prediction = await client.getPricePrediction(
-          PricePredictionToken.BTC,
-          PricePredictionTimeframe.EIGHT_HOURS,
+        const inference = await client.getPriceInference(
+          PriceInferenceToken.BTC,
+          PriceInferenceTimeframe.EIGHT_HOURS,
         );
 
-        expect(prediction).toHaveProperty("signature");
-        expect(prediction).toHaveProperty("inference_data");
-        expect(prediction.inference_data).toHaveProperty("network_inference");
-        expect(prediction.inference_data).toHaveProperty(
+        expect(inference).toHaveProperty("signature");
+        expect(inference).toHaveProperty("inference_data");
+        expect(inference.inference_data).toHaveProperty("network_inference");
+        expect(inference.inference_data).toHaveProperty(
           "network_inference_normalized",
         );
       },

--- a/test/api-client.unit.test.ts
+++ b/test/api-client.unit.test.ts
@@ -1,8 +1,8 @@
 import {
   AlloraAPIClient,
   ChainSlug,
-  PricePredictionToken,
-  PricePredictionTimeframe,
+  PriceInferenceToken,
+  PriceInferenceTimeframe,
   ChainID,
   SignatureFormat,
 } from "../src/v2";
@@ -147,27 +147,27 @@ describe("AlloraAPIClient Unit Tests", () => {
     });
   });
 
-  describe("getPricePrediction", () => {
-    it("should fetch price prediction data correctly", async () => {
+  describe("getPriceInference", () => {
+    it("should fetch price inference data correctly", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockAPIResponse),
       });
 
-      const prediction = await client.getPricePrediction(
-        PricePredictionToken.BTC,
-        PricePredictionTimeframe.FIVE_MIN,
+      const inference = await client.getPriceInference(
+        PriceInferenceToken.BTC,
+        PriceInferenceTimeframe.FIVE_MIN,
       );
 
-      expect(prediction.inference_data.network_inference).toEqual(
+      expect(inference.inference_data.network_inference).toEqual(
         mockInference.inference_data.network_inference,
       );
-      expect(prediction.inference_data.network_inference_normalized).toEqual(
+      expect(inference.inference_data.network_inference_normalized).toEqual(
         mockInference.inference_data.network_inference_normalized,
       );
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining(
-          `/allora/consumer/price/${SignatureFormat.ETHEREUM_SEPOLIA}/${PricePredictionToken.BTC}/${PricePredictionTimeframe.FIVE_MIN}`,
+          `/allora/consumer/price/${SignatureFormat.ETHEREUM_SEPOLIA}/${PriceInferenceToken.BTC}/${PriceInferenceTimeframe.FIVE_MIN}`,
         ),
         expect.any(Object),
       );
@@ -184,11 +184,11 @@ describe("AlloraAPIClient Unit Tests", () => {
       });
 
       await expect(
-        client.getPricePrediction(
-          PricePredictionToken.BTC,
-          PricePredictionTimeframe.FIVE_MIN,
+        client.getPriceInference(
+          PriceInferenceToken.BTC,
+          PriceInferenceTimeframe.FIVE_MIN,
         ),
-      ).rejects.toThrow("Failed to fetch price prediction");
+      ).rejects.toThrow("Failed to fetch price inference");
     });
 
     it("should throw an error if the API request fails", async () => {
@@ -198,9 +198,9 @@ describe("AlloraAPIClient Unit Tests", () => {
         json: () => Promise.resolve({}),
       });
       await expect(
-        client.getPricePrediction(
-          PricePredictionToken.BTC,
-          PricePredictionTimeframe.FIVE_MIN,
+        client.getPriceInference(
+          PriceInferenceToken.BTC,
+          PriceInferenceTimeframe.FIVE_MIN,
         ),
       ).rejects.toThrow();
     });


### PR DESCRIPTION
Main changes added:
- change wording to use "inference" instead of "prediction"
- bump the minor version of the package. New package version: `0.1.0`