### PR TITLE
DEVOP-553: add .npmrc with ignore-scripts=true default

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+# Security: Shai-Hulud supply-chain worm mitigation.
+# - ignore-scripts: block preinstall/install/postinstall lifecycle scripts by
+#   default. If a package legitimately needs a build script (native module),
+#   add it to package.json#pnpm.onlyBuiltDependencies.
+# - fund / audit: suppress noisy non-security network calls during install.
+# See DEVOP-553.
+ignore-scripts=true
+fund=false
+audit=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,9 +1,36 @@
-# Security: Shai-Hulud supply-chain worm mitigation.
-# - ignore-scripts: block preinstall/install/postinstall lifecycle scripts by
-#   default. If a package legitimately needs a build script (native module),
-#   add it to package.json#pnpm.onlyBuiltDependencies.
-# - fund / audit: suppress noisy non-security network calls during install.
-# See DEVOP-553.
+# Security: Shai-Hulud supply-chain worm mitigation. See DEVOP-553.
+#
+# DO NOT add credentials here. This file must never contain `_authToken`
+# or any registry credentials; .npmrc is a common credential-leak vector.
+# This file is excluded from the published @alloralabs/allora-sdk tarball
+# by package.json#files (allow-list of `/dist`); verify with
+# `npm pack --dry-run` before release.
+#
+# Scope: this project-local .npmrc is only honored when install runs in
+# the repo root. CI workflows or Dockerfiles that copy package.json /
+# yarn.lock without copying .npmrc will silently bypass these settings;
+# for defense in depth pair with workflow/org-level
+# NPM_CONFIG_IGNORE_SCRIPTS=true / YARN_IGNORE_SCRIPTS=true. (This repo's
+# GitHub Actions use actions/checkout which copies .npmrc, and there are
+# no Dockerfiles, so CI honors these settings today.)
+#
+# Settings:
+# - ignore-scripts=true: block preinstall/install/postinstall lifecycle
+#   scripts at install time. Honored by yarn 1 (this repo's
+#   packageManager) and npm. This also blocks first-party lifecycle
+#   scripts (preinstall/postinstall/prepare) defined in this repo's
+#   package.json; invoke them explicitly via `yarn run <script>` when
+#   needed. If a dependency legitimately requires a build script (e.g.
+#   a native module), the yarn 1 escape hatch is a temporary
+#   `yarn install --ignore-scripts=false` (or vendor/prebuild the
+#   artifact). Under pnpm the equivalent is whitelisting in
+#   package.json#pnpm.onlyBuiltDependencies.
+# - fund=false / audit=false: suppress noisy non-security network calls
+#   during install. Note: yarn 1 does not invoke `npm audit` or
+#   `npm fund` at install, so these are effectively no-ops here and
+#   only take effect if `npm install` is run directly. They are kept
+#   as defensive cross-tool defaults; vulnerability scanning is
+#   performed out-of-band (e.g. Dependabot / GHAS).
 ignore-scripts=true
 fund=false
 audit=false


### PR DESCRIPTION
## Summary

Adds a root `.npmrc` that blocks `preinstall` / `install` / `postinstall` lifecycle scripts by default — Shai-Hulud supply-chain worm mitigation. If a package later requires a build script (native module like `esbuild`, `@swc/core`, `better-sqlite3`, etc.), add it to `package.json#pnpm.onlyBuiltDependencies`.

Also disables fund/audit's noisy non-security network calls during install.

## File added

```
ignore-scripts=true
fund=false
audit=false
```

## Test plan

- [ ] CI passes. If a native module's build is skipped and the test/build step fails as a result, that's the signal to add it to `pnpm.onlyBuiltDependencies` — please do that in a follow-up commit on this PR.
- [ ] Verify with `pnpm install --reporter=ndjson` locally that any skipped script outputs are expected.

Linear: https://linear.app/alloralabs/issue/DEVOP-553

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root `.npmrc` with `ignore-scripts=true` to block install lifecycle scripts and reduce supply‑chain risk. Also sets `fund=false` and `audit=false`, and updates inline docs on yarn 1 behavior, CI env vars, and credential safety; aligns with Linear DEVOP-553.

- **Migration**
  - If a native module needs a build, temporarily allow scripts (yarn: `yarn install --ignore-scripts=false`) or prebuild/vendor; for pnpm repos, add it to `package.json` `pnpm.onlyBuiltDependencies`.
  - Lifecycle hooks (including this repo’s) are blocked; run needed steps explicitly (e.g., `yarn run <script>`). Keep any allowlists minimal.

<sup>Written for commit 4a58f5f9466a11be18932643c57a87466223aa17. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-sdk-ts/pull/11?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

