### PR TITLE
DEVOP-555: yarn install --frozen-lockfile --ignore-scripts

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -26,7 +26,10 @@ jobs:
         run: corepack enable && corepack prepare yarn@1.22.22 --activate
 
       - name: Install dependencies with yarn
-        run: yarn install
+        # Security: --frozen-lockfile prevents transitive-dep drift in CI;
+        # --ignore-scripts blocks postinstall execution (Shai-Hulud
+        # supply-chain worm mitigation). See DEVOP-555.
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Run ESLint
         run: yarn lint

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -21,7 +21,6 @@ jobs:
           node-version: '18.x'
 
       # ESLint and Prettier must be in `package.json`
-      # --frozen-lockfile ensures lockfile will not be updated
       - name: Install yarn via corepack
         run: corepack enable && corepack prepare yarn@1.22.22 --activate
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,10 @@ jobs:
       run: corepack enable && corepack prepare yarn@1.22.22 --activate
     
     - name: Install dependencies with yarn
-      run: yarn install
+      # Security: --frozen-lockfile prevents transitive-dep drift in CI;
+      # --ignore-scripts blocks postinstall execution (Shai-Hulud
+      # supply-chain worm mitigation). See DEVOP-555.
+      run: yarn install --frozen-lockfile --ignore-scripts
 
     - name: Run unit tests
       if: matrix.test-type == 'unit'


### PR DESCRIPTION
## Summary

Shai-Hulud worm mitigation. Both `linter.yaml` and `test.yaml` use yarn 1 (packageManager pin is `yarn@1.22.22`, yarn.lock is v1), so the standard CLI flags apply:

- `--frozen-lockfile` prevents fresh resolution of transitive deps in CI (no silent drift onto a poisoned version).
- `--ignore-scripts` blocks any `preinstall` / `install` / `postinstall` script from executing.

## Test plan

- [ ] Both workflows pass on this PR with the new flags. If a package legitimately needs a build script, allowlist it via a follow-up commit (yarn 1 doesn't have native granular allowlist; need to drop `--ignore-scripts` on the specific install and add explicit safeguards).

Linear: https://linear.app/alloralabs/issue/DEVOP-555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI installs by switching to `yarn install --frozen-lockfile --ignore-scripts` in `.github/workflows/linter.yaml` and `.github/workflows/test.yaml`, pinning deps and blocking lifecycle scripts for `yarn@1.22.22` per DEVOP-555. Cleaned up a stale `--frozen-lockfile` comment left above the corepack step.

<sup>Written for commit 2c823f66c2bda0d6711e0c9939452a217e0a432c. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-sdk-ts/pull/12?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

